### PR TITLE
Add keywords support to uses_products

### DIFF
--- a/HempResourceHub/shared/schema.ts
+++ b/HempResourceHub/shared/schema.ts
@@ -97,7 +97,10 @@ export const usesProducts = pgTable("uses_products", {
   historicalContextFacts: text("historical_context_facts").array(),
   technicalSpecifications: jsonb("technical_specifications"),
   miscellaneousInfo: jsonb("miscellaneous_info"),
+  // keywords used for full-text search
   keywords: text("keywords").array(),
+  // stored tsvector column generated from name, description and keywords
+  searchVector: text("search_vector"),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow().$onUpdate(() => new Date()),
 });

--- a/HempResourceHub/supabase/migrations/20250604020000_add_keywords_to_uses_products/up.sql
+++ b/HempResourceHub/supabase/migrations/20250604020000_add_keywords_to_uses_products/up.sql
@@ -1,0 +1,16 @@
+ALTER TABLE public.uses_products
+    ADD COLUMN IF NOT EXISTS keywords TEXT[];
+
+-- Recreate search_vector to include keywords
+DROP INDEX IF EXISTS uses_products_search_idx;
+ALTER TABLE public.uses_products DROP COLUMN IF EXISTS search_vector;
+ALTER TABLE public.uses_products
+    ADD COLUMN search_vector TSVECTOR GENERATED ALWAYS AS (
+        to_tsvector('english',
+            coalesce(name, '') || ' ' ||
+            coalesce(description, '') || ' ' ||
+            coalesce(array_to_string(keywords, ' '), '')
+        )
+    ) STORED;
+
+CREATE INDEX uses_products_search_idx ON public.uses_products USING GIN (search_vector);

--- a/schema.sql
+++ b/schema.sql
@@ -39,11 +39,6 @@ CREATE TABLE IF NOT EXISTS public.industry_sub_categories (
 );
 CREATE INDEX IF NOT EXISTS idx_industry_sub_categories_industry_id ON public.industry_sub_categories(industry_id);
 
--- TODO: Add keywords field and update search_vector for uses_products
--- PLANNED ADDITION for uses_products table:
--- keywords TEXT[],
--- PLANNED UPDATE for uses_products.search_vector:
--- search_vector TSVECTOR GENERATED ALWAYS AS (to_tsvector('english', coalesce(name, '') || ' ' || coalesce(description, '') || ' ' || coalesce(array_to_string(keywords, ' '), ''))) STORED,
 CREATE TABLE IF NOT EXISTS public.uses_products (
     id BIGSERIAL PRIMARY KEY,
     name TEXT NOT NULL,
@@ -57,7 +52,14 @@ CREATE TABLE IF NOT EXISTS public.uses_products (
     historical_context_facts TEXT[],
     technical_specifications JSONB,
     miscellaneous_info JSONB,
-    search_vector TSVECTOR GENERATED ALWAYS AS (to_tsvector('english', coalesce(name, '') || ' ' || coalesce(description, ''))) STORED,
+    keywords TEXT[],
+    search_vector TSVECTOR GENERATED ALWAYS AS (
+        to_tsvector('english',
+            coalesce(name, '') || ' ' ||
+            coalesce(description, '') || ' ' ||
+            coalesce(array_to_string(keywords, ' '), '')
+        )
+    ) STORED,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );


### PR DESCRIPTION
## Summary
- support keywords in SQL schema
- expose keywords column in Drizzle schema
- regenerate search vector based on keywords
- add migration script for Supabase

## Testing
- `python -m py_compile populate_hemp_products_advanced.py populate_supabase_db.py && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_683fa7e4d8b48321843d974b1e6a075c