### PR TITLE
Update README to emphasize npm install

### DIFF
--- a/HempResourceHub/README.md
+++ b/HempResourceHub/README.md
@@ -87,7 +87,9 @@ This will create the tables with full-text search capabilities.
 ## Getting Started
 
 1. Clone the repository
-2. Install dependencies: `npm install`
+2. **Install dependencies first**: `npm install`
+   - Run this command before executing any `npm run` scripts.
+   - `npm run check` in particular relies on packages in the `node_modules` directory.
 3. Set up environment variables in `.env`:
    ```
    VITE_SUPABASE_URL=your_supabase_url


### PR DESCRIPTION
## Summary
- highlight that dependencies should be installed before any npm run commands
- mention npm run check needs node_modules

## Testing
- `npm install`
- `npm run check` *(fails: no exported members)*

------
https://chatgpt.com/codex/tasks/task_e_683faaad874c83218d26950c55bb6911